### PR TITLE
修改文档克隆的仓库地址

### DIFF
--- a/walle-web.io/docs/en/intallation.md
+++ b/walle-web.io/docs/en/intallation.md
@@ -15,7 +15,7 @@ Requirements
 ------------
 ```
 mkdir -p /data/www/walle-web && cd /data/www/walle-web  # A place to store
-git clone git@github.com:meolu/walle-web.git .          # clone is easy for update
+git clone https://github.com/meolu/walle-web.git .          # clone is easy for update
 ```
 
 

--- a/walle-web.io/docs/zh-cn/installation.md
+++ b/walle-web.io/docs/zh-cn/installation.md
@@ -4,7 +4,7 @@ title: 安装
 1.简洁安装指南
 ============
 ```
-git clone git@github.com:meolu/walle-web.git
+git clone https://github.com/meolu/walle-web.git
 cd walle-web
 vi config/web.php # 设置mysql连接
 composer install  # 如果缺少bower-asset的话， 先安装：composer global require "fxp/composer-asset-plugin:*"
@@ -24,7 +24,7 @@ composer install  # 如果缺少bower-asset的话， 先安装：composer global
 ----------
 ```
 mkdir -p /data/www/walle-web && cd /data/www/walle-web  # 新建目录
-git clone git@github.com:meolu/walle-web.git .          # 代码检出
+git clone https://github.com/meolu/walle-web.git .          # 代码检出
 ```
 
 


### PR DESCRIPTION
ssh克隆容易遇到权限问题。今天有其它同事在安装也遇到这个问题，所以特地修改了一份，改为https方式的仓库地址，人人能clone。